### PR TITLE
feat(app, backend, db): update slash command behaviors

### DIFF
--- a/app/commands/add.js
+++ b/app/commands/add.js
@@ -1,0 +1,105 @@
+import { SlashCommandBuilder } from "discord.js";
+import { announceGameList } from "../utils/announceGameList.js";
+import { serviceFetch } from "../utils/serviceFetch.js";
+import { generateRandomHexArray } from "../utils/generateRandomHexArray.js";
+
+// Dear god refactor all of this
+export const add = {
+  data: new SlashCommandBuilder()
+    .setName("add")
+    .setDescription("Add a new game")
+    .addStringOption((option) =>
+      option
+        .setName("name")
+        .setDescription("The name of the new game you want to add.")
+        .setMaxLength(30)
+        .setRequired(true)
+    )
+    .addIntegerOption((option) =>
+      option
+        .setName("size")
+        .setDescription("The maximum party size for this game.")
+    )
+    .addStringOption((option) =>
+      option
+        .setName("aliases")
+        .setDescription("A comma separated list of aliases for this game.")
+        .setMaxLength(50)
+    ),
+  async execute(interaction) {
+    try {
+      const gameName = interaction.options.getString("name");
+      const partySize = interaction.options.getInteger("size");
+      const aliases =
+        interaction.options.getString("aliases")?.split(",") || [];
+
+      // Ensure the game name or alias do not exist already
+      try {
+        const { games, status } = await serviceFetch({
+          path: "/game",
+          method: "POST",
+          body: { gameName, aliases },
+        });
+        if (status !== 0) throw new Error("Unable to search for game");
+        if (games?.length) {
+          let errors = [];
+          games.forEach((game) => {
+            if (game.game_name === gameName) {
+              errors.push(`${gameName} is already registered.`);
+            }
+            aliases.forEach((alias) => {
+              game.aliases.includes(alias)
+                ? errors.push(
+                    `Alias ${alias} is already registered to ${game.game_name}`
+                  )
+                : null;
+            });
+          });
+          return interaction.reply(errors.join(" "));
+        }
+      } catch (e) {
+        throw e;
+      }
+
+      // Phew, i think we made it. Create the role.
+      const role = await interaction.guild.roles.create({
+        name: gameName,
+        color: generateRandomHexArray(),
+      });
+      if (!role.id) throw new Error("Unable to create role");
+
+      // // Add the role to the database
+      try {
+        const { status } = await serviceFetch({
+          path: "/game/add",
+          method: "POST",
+          body: {
+            roleId: role.id,
+            gameName,
+            maxPartySize: partySize,
+            aliases,
+          },
+        });
+        if (status !== 0) throw new Error("Failed to add game to db");
+      } catch (e) {
+        throw e;
+      }
+
+      // Add the role to the user.
+      await interaction.member.roles.add(role);
+
+      // Send the message to the announcement channel
+      await announceGameList(interaction.client);
+
+      return interaction.reply(
+        `${gameName} was registered ${
+          aliases.length ? `with aliases ${aliases}` : ""
+        }`
+      );
+    } catch (e) {
+      // TODO: Rollback logic
+      console.error(e);
+      await interaction.reply("Something broke. Great job.");
+    }
+  },
+};

--- a/app/commands/start.js
+++ b/app/commands/start.js
@@ -26,7 +26,7 @@ export const start = {
         .setStyle(ButtonStyle.Secondary),
       new ButtonBuilder()
         .setCustomId("in-a-bit")
-        .setLabel("In a little bit")
+        .setLabel("In a bit")
         .setStyle(ButtonStyle.Secondary)
     );
     try {

--- a/app/index.js
+++ b/app/index.js
@@ -54,7 +54,6 @@ for (const file of commandFiles) {
 // We use 'c' for the event parameter to keep it separate from the already defined 'client'
 client.once(Events.ClientReady, async (c) => {
   console.log(`Ready! Logged in as ${c.user.tag}`);
-  await announceGameList(client);
 });
 
 // Slash commands
@@ -159,25 +158,14 @@ client.on(Events.InteractionCreate, async (interaction) => {
   }
 });
 
-// Register for games with an emoji
-client.on(Events.MessageReactionAdd, async (reaction, user) => {
+// Autocompletes
+client.on(Events.InteractionCreate, async (interaction) => {
+  if (!interaction.isAutocomplete()) return;
   try {
-    const message = await reaction.message.fetch();
-    if (
-      message.content.includes("---GAME NOTIFICATIONS---") &&
-      message.author.id === process.env.CLIENT_ID
-    ) {
-      const { games } = await serviceFetch({
-        path: `/game`,
-        method: "POST",
-        body: { registrationEmoji: reaction._emoji.name },
-      });
-      const role = await reaction.message.guild.roles.fetch(games?.[0].role_id);
-      await reaction.message.guild.members.addRole({ user, role });
-      await user.send(`You've been registered to ${games?.[0].game_name}!`);
-    }
+    const command = interaction.client.commands.get(interaction.commandName);
+    command.autocomplete(interaction);
   } catch (e) {
-    console.log(e);
+    console.error(e);
   }
 });
 

--- a/app/index.js
+++ b/app/index.js
@@ -84,9 +84,12 @@ client.on(Events.InteractionCreate, async (interaction) => {
   if (!interaction.isButton()) return;
   try {
     const nickname = interaction.member.nickname || interaction.user.globalName;
-    let partyMembers;
-    let maxPartySize;
-    let partyFull;
+    const { party_members, max_party_size } = await serviceFetch({
+      path: `/session/${interaction.message.id}`,
+    });
+    let partyMembers = party_members;
+    let maxPartySize = max_party_size;
+    let partyFull = false;
 
     if (
       interaction.customId === "drop-in" ||
@@ -129,7 +132,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
 
     const [original, _] = interaction.message.content.split("\n");
     let interactionObj;
-    if (partyMembers?.length > 0) {
+    if (partyMembers?.length > 0 || interaction.customId === "in-a-bit") {
       interactionObj = {
         content: startSessionStringBuilder({
           original,

--- a/app/scripts/delete-guild-commands.js
+++ b/app/scripts/delete-guild-commands.js
@@ -1,0 +1,26 @@
+import { REST, Routes } from "discord.js";
+
+// Construct and prepare an instance of the REST module
+const rest = new REST({ version: "10" }).setToken(process.env.TOKEN);
+
+(async () => {
+  try {
+    console.log(`Started removing guild (/) commands.`);
+
+    // The put method is used to fully refresh all commands in the guild with the current set
+    await rest.put(
+      Routes.applicationGuildCommands(
+        process.env.CLIENT_ID,
+        process.env.GUILD_ID
+      ),
+      { body: [] }
+    );
+
+    console.log(`Successfully removed guild (/) commands.`);
+
+    // Uncomment this to remove guild
+  } catch (error) {
+    // And of course, make sure you catch and log any errors!
+    console.error(error);
+  }
+})();

--- a/app/scripts/deploy-commands.js
+++ b/app/scripts/deploy-commands.js
@@ -3,13 +3,13 @@ import { readdirSync } from "fs";
 
 const commands = [];
 // Grab all the command files from the commands directory you created earlier
-const commandFiles = readdirSync("./commands").filter((file) =>
+const commandFiles = readdirSync("../commands").filter((file) =>
   file.endsWith(".js")
 );
 
 // Grab the SlashCommandBuilder#toJSON() output of each command's data for deployment
 for (const file of commandFiles) {
-  const command = await import(`./commands/${file}`);
+  const command = await import(`../commands/${file}`);
   const key = file.split(".")[0];
   commands.push(command[key].data.toJSON());
 }
@@ -26,16 +26,15 @@ const rest = new REST({ version: "10" }).setToken(process.env.TOKEN);
 
     // The put method is used to fully refresh all commands in the guild with the current set
     const data = await rest.put(
-      Routes.applicationGuildCommands(
-        process.env.CLIENT_ID,
-        process.env.GUILD_ID
-      ),
+      Routes.applicationCommands(process.env.CLIENT_ID, process.env.GUILD_ID),
       { body: commands }
     );
 
     console.log(
       `Successfully reloaded ${data.length} application (/) commands.`
     );
+
+    // Uncomment this to remove guild
   } catch (error) {
     // And of course, make sure you catch and log any errors!
     console.error(error);

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -5,19 +5,14 @@ const routes = async (fastify, options) => {
   // Get all games
   fastify.get("/games", async function handler(request, reply) {
     const [result, _] = await fastify.mysql.query(GAMES.FIND_GAMES);
-    return replyHandler(reply, true, result);
+    return replyHandler(reply, true, { games: result });
   });
 
   // Get game by identifier
   fastify.post("/game", async function handler(request, reply) {
-    const {
-      gameName = "",
-      registrationEmoji = "",
-      aliases = [],
-    } = request.body;
+    const { gameName = "", aliases = [] } = request.body;
     const [result, _] = await fastify.mysql.query(GAMES.FIND_GAME, [
       gameName,
-      registrationEmoji,
       JSON.stringify(aliases),
     ]);
     return replyHandler(reply, true, { games: result.slice(3).flat() });
@@ -29,7 +24,6 @@ const routes = async (fastify, options) => {
       request.body.roleId,
       request.body.gameName,
       request.body.maxPartySize,
-      request.body.registrationEmoji,
       JSON.stringify(request.body.aliases),
     ]);
     replyHandler(reply, result?.affectedRows > 0);

--- a/backend/routes/sessions.js
+++ b/backend/routes/sessions.js
@@ -33,14 +33,9 @@ const routes = async (fastify, options) => {
     addSessionSchema,
     async function handler(request, reply) {
       // Find the game in the game table if it already exists
-      const {
-        gameName = "",
-        registrationEmoji = "",
-        aliases = [],
-      } = request.body;
+      const { gameName = "", aliases = [] } = request.body;
       const [games, _a] = await fastify.mysql.query(GAMES.FIND_GAME, [
         gameName,
-        registrationEmoji,
         JSON.stringify(aliases),
       ]);
       // Add the session

--- a/backend/routes/sessions.js
+++ b/backend/routes/sessions.js
@@ -54,6 +54,15 @@ const routes = async (fastify, options) => {
     }
   );
 
+  // Get a session by message id - has game info included.
+  fastify.get("/session/:id", async function handler(request, reply) {
+    const [result, _] = await fastify.mysql.query(
+      SESSIONS.GET_SESSION_WITH_GAME,
+      [request.params.id]
+    );
+    replyHandler(reply, result.length > 0, result[0]);
+  });
+
   // Remove a session by message id
   fastify.delete("/session/:id", async function handler(request, reply) {
     const [result, _] = await fastify.mysql.query(SESSIONS.REMOVE_SESSION, [

--- a/backend/sql/games.js
+++ b/backend/sql/games.js
@@ -1,5 +1,5 @@
 export const GAMES = {
   FIND_GAMES: `SELECT * from games`,
-  FIND_GAME: `SET @game_name := ?; SET @registration_emoji := ?; SET @aliases := ?; SELECT * FROM games WHERE game_name=@game_name; SELECT * FROM games WHERE registration_emoji=@registration_emoji; SELECT * FROM games WHERE JSON_OVERLAPS(aliases, @aliases);`,
-  ADD_GAME: `INSERT INTO games (role_id, game_name, max_party_size, registration_emoji, aliases) VALUES (?, ?, ?, ?, ?)`,
+  FIND_GAME: `SET @game_name := ?; SET @aliases := ?; SELECT * FROM games WHERE game_name=@game_name; SELECT * FROM games WHERE JSON_OVERLAPS(aliases, @aliases);`,
+  ADD_GAME: `INSERT INTO games (role_id, game_name, max_party_size, aliases) VALUES (?, ?, ?, ?)`,
 };

--- a/db/init.sql
+++ b/db/init.sql
@@ -14,7 +14,6 @@ CREATE TABLE `games` (
   `role_id` varchar(20) NOT NULL,
   `game_name` varchar(100) NOT NULL,
   `max_party_size` int DEFAULT NULL,
-  `registration_emoji` char(1) NOT NULL,
   `aliases` json DEFAULT NULL,
   PRIMARY KEY (`game_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
Big change here. Registering with emojis was clunky (custom emojis, complex unicode emojis), hard to register, and hard to explain so that feature has been removed.

Instead, the `/register` command has been repurposed to be used to assign a role to yourself.

In place of register, `/add` will take over, which behaves the same way but no longer requires an emoji argument.

Also, the "In a bit" button has been fixed.

Finally, a script was added to remove extraneous commands.